### PR TITLE
Fix docstrings to match new `FileStorage` location

### DIFF
--- a/flask_uploads.py
+++ b/flask_uploads.py
@@ -379,13 +379,16 @@ class UploadSet(object):
         return os.path.join(target_folder, filename)
 
     def file_allowed(self, storage, basename):
-        """
-        This tells whether a file is allowed. It should return `True` if the
-        given `werkzeug.FileStorage` object can be saved with the given
-        basename, and `False` if it can't. The default implementation just
-        checks the extension, so you can override this if you want.
+        """This tells whether a file is allowed.
 
-        :param storage: The `werkzeug.FileStorage` to check.
+        It should return `True` if the given
+        `werkzeug.datastructures.FileStorage` object can be saved with
+        the given basename, and `False` if it can't.
+
+        The default implementation just checks the extension,
+        so you can override this if you want.
+
+        :param storage: The `werkzeug.datastructures.FileStorage` to check.
         :param basename: The basename it will be saved under.
         """
         return self.extension_allowed(extension(basename))
@@ -405,9 +408,13 @@ class UploadSet(object):
         return lowercase_ext(secure_filename(filename))
 
     def save(self, storage, folder=None, name=None):
-        """
-        This saves a `werkzeug.FileStorage` into this upload set. If the
-        upload is not allowed, an `UploadNotAllowed` error will be raised.
+        """This saves the `storage` into this upload set.
+
+        A `storage` is a `werkzeug.datastructures.FileStorage`.
+
+        If the upload is not allowed,
+        an `UploadNotAllowed` error will be raised.
+
         Otherwise, the file will be saved and its name (including the folder)
         will be returned.
 

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ from __future__ import with_statement
 
 import os.path
 
+import pytest
 from flask import Flask
 from flask import url_for
 
@@ -245,6 +246,18 @@ class TestSaving(object):
         res2 = uset.save(tfs2)
         assert res2 == 'myapp.wsgi'
         assert tfs2.saved == '/uploads/myapp.wsgi'
+
+    def test_storage_is_not_a_werkzeug_datastructure(self):
+        """UploadSet.save needs a valid FileStorage object.
+
+        When something different is passed in, a TypeError gets raised.
+        """
+        uset = UploadSet('files', ALL)
+        uset._config = Config('/uploads')
+        non_storage = 'this is no werkzeug.datastructure.FileStorage'
+
+        with pytest.raises(TypeError):
+            uset.save(non_storage)
 
 
 class TestConflictResolution(object):

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
     check-python-versions {posargs}
 
 [isort]
-known_third_party = flask,setuptools,sphinx_rtd_theme,werkzeug
+known_third_party = flask,pytest,setuptools,sphinx_rtd_theme,werkzeug
 force_single_line = True
 
 [flake8]


### PR DESCRIPTION
When Werkzeug 1.0 was released, the import API changed.

The import for `FileStorage` was fixed, but the docstrings were
not updated.

Also, a test has been written to catch the case when not a proper
`FileStorage` was provided.

modified:   flask_uploads.py
modified:   tests.py
modified:   tox.ini