### PR TITLE
Deprecate `patch_request_class`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 unreleased
 ----------
+- deprecate `patch_request_class`
+  (`#43 <https://github.com/jugmac00/flask-reuploaded/issues/43>`_)
 - use a `src` directory for source code
   (`#21 <https://github.com/jugmac00/flask-reuploaded/issues/21>`_)
 - add tox env for check-python-versions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,8 +60,8 @@ then they will be served internally by Flask. They are just there so if you
 have heavy upload traffic, you can have a faster production server like Nginx
 serve the uploads.
 
-Since Flask 0.6 you can set `MAX_CONTENT_LENGTH` to
-limit the size of uploaded files.
+By default Flask doesn't put any limits on the size of the uploaded
+data. To limit the max upload size, you can use Flask's `MAX_CONTENT_LENGTH`.
 
 
 Upload Sets
@@ -116,18 +116,6 @@ You pass in the app and all of the upload sets you want configured. Calling
 
 If your app has a factory function, that is a good place to call this
 function.
-
-By default, though, Flask doesn't put any limits on the size of the uploaded
-data. To protect your application, you can use `patch_request_class`. If you
-call it with `None` as the second parameter, it will use the
-`MAX_CONTENT_LENGTH` setting to determine how large the upload can be. ::
-
-    patch_request_class(app, None)
-
-You can also call it with a number to set an absolute limit, but that only
-exists for backwards compatibility reasons and is not recommended for
-production use. In addition, it's not necessary for Flask 0.6 or greater, so
-if your application is only intended to run on Flask 0.6, you don't need it.
 
 
 File Upload Forms
@@ -203,6 +191,12 @@ Testing Utilities
 
 Backwards Compatibility
 =======================
+
+Version 1.0 (unreleased)
+------------------------
+* Removal of `patch_request_class`
+
+
 Version 0.1.3
 -------------
 * The `_uploads` module/blueprint will not be registered if it is not needed

--- a/src/flask_uploads/__init__.py
+++ b/src/flask_uploads/__init__.py
@@ -12,7 +12,6 @@ from .flask_uploads import addslash
 from .flask_uploads import configure_uploads
 from .flask_uploads import extension
 from .flask_uploads import lowercase_ext
-from .flask_uploads import patch_request_class
 from .flask_uploads import config_for_set
 
 from .flask_uploads import ALL
@@ -27,6 +26,8 @@ from .flask_uploads import ARCHIVES
 from .flask_uploads import SOURCE
 from .flask_uploads import EXECUTABLES
 from .flask_uploads import DEFAULTS
+
+from .backwards_compatibility import patch_request_class
 
 
 __all__ = [

--- a/src/flask_uploads/backwards_compatibility.py
+++ b/src/flask_uploads/backwards_compatibility.py
@@ -1,0 +1,51 @@
+import warnings
+
+
+def patch_request_class(app, size=64 * 1024 * 1024):  # pragma: no cover
+    """Attention!
+
+    This function is deprecated and due to removal in `Flask-Reuploaded 1.0`.
+
+    It was necessary to restrict the max upload size,
+    back in the days of Flask 0.6 and earlier.
+
+    By default, Flask will accept uploads to an arbitrary size. While Werkzeug
+    switches uploads from memory to a temporary file when they hit 500 KiB,
+    it's still possible for someone to overload your disk space with a
+    gigantic file.
+
+    This patches the app's request class's
+    `~werkzeug.BaseRequest.max_content_length` attribute so that any upload
+    larger than the given size is rejected with an HTTP error.
+
+    .. note::
+
+       In Flask 0.6, you can do this by setting the `MAX_CONTENT_LENGTH`
+       setting, without patching the request class. To emulate this behavior,
+       you can pass `None` as the size (you must pass it explicitly). That is
+       the best way to call this function, as it won't break the Flask 0.6
+       functionality if it exists.
+
+    .. versionchanged:: 0.1.1
+
+    :param app: The app to patch the request class of.
+    :param size: The maximum size to accept, in bytes. The default is 64 MiB.
+                 If it is `None`, the app's `MAX_CONTENT_LENGTH` configuration
+                 setting will be used to patch.
+    """
+    warnings.warn(
+        "`patch_request_class` is deprecated "
+        "and due for removal in `Flask-Reuploaded 1.0. "
+        "Please use `MAX_CONTENT_LENGTH` instead. "
+        "For further help please see the documentation.",
+        DeprecationWarning
+    )
+    if size is None:
+        if isinstance(app.request_class.__dict__['max_content_length'],
+                      property):
+            return
+        size = app.config.get('MAX_CONTENT_LENGTH')
+    reqclass = app.request_class
+    patched = type(reqclass.__name__, (reqclass,),
+                   {'max_content_length': size})
+    app.request_class = patched

--- a/src/flask_uploads/flask_uploads.py
+++ b/src/flask_uploads/flask_uploads.py
@@ -133,43 +133,6 @@ def addslash(url):
     return url + '/'
 
 
-def patch_request_class(app, size=64 * 1024 * 1024):
-    """
-    By default, Flask will accept uploads to an arbitrary size. While Werkzeug
-    switches uploads from memory to a temporary file when they hit 500 KiB,
-    it's still possible for someone to overload your disk space with a
-    gigantic file.
-
-    This patches the app's request class's
-    `~werkzeug.BaseRequest.max_content_length` attribute so that any upload
-    larger than the given size is rejected with an HTTP error.
-
-    .. note::
-
-       In Flask 0.6, you can do this by setting the `MAX_CONTENT_LENGTH`
-       setting, without patching the request class. To emulate this behavior,
-       you can pass `None` as the size (you must pass it explicitly). That is
-       the best way to call this function, as it won't break the Flask 0.6
-       functionality if it exists.
-
-    .. versionchanged:: 0.1.1
-
-    :param app: The app to patch the request class of.
-    :param size: The maximum size to accept, in bytes. The default is 64 MiB.
-                 If it is `None`, the app's `MAX_CONTENT_LENGTH` configuration
-                 setting will be used to patch.
-    """
-    if size is None:
-        if isinstance(app.request_class.__dict__['max_content_length'],
-                      property):
-            return
-        size = app.config.get('MAX_CONTENT_LENGTH')
-    reqclass = app.request_class
-    patched = type(reqclass.__name__, (reqclass,),
-                   {'max_content_length': size})
-    app.request_class = patched
-
-
 def config_for_set(uset, app, defaults=None):
     """
     This is a helper function for `configure_uploads` that extracts the


### PR DESCRIPTION
... and move it out of the main module.

This function was only necessary in the pre-Flask 0.6 time.

This fixes #43

modified:   docs/index.rst
modified:   src/flask_uploads/__init__.py
new file:   src/flask_uploads/backwards_compatibility.py
modified:   src/flask_uploads/flask_uploads.py
modified:   CHANGES.rst