### PR TITLE
Explicitly import os

### DIFF
--- a/src/flask_uploads/flask_uploads.py
+++ b/src/flask_uploads/flask_uploads.py
@@ -8,7 +8,7 @@ an `UploadSet` object and upload your files to it.
 :copyright: 2010 Matthew "LeafStorm" Frazier
 :license:   MIT/X11, see LICENSE for details
 """
-
+import os
 import os.path
 import posixpath
 

--- a/tests/test_flask_reuploaded.py
+++ b/tests/test_flask_reuploaded.py
@@ -5,12 +5,12 @@
 """
 from __future__ import with_statement
 
+import os
 import os.path
 
 import pytest
 from flask import Flask
 from flask import url_for
-
 from flask_uploads import ALL
 from flask_uploads import AllExcept
 from flask_uploads import TestingFileStorage


### PR DESCRIPTION
`os.makedirs` was used, but only `os.path` was imported.

This worked because of a side effect, import `os.path` made `os`
available in current name space.

pyright made me aware of this problem.

Eric Traut explained why pyright works as designed.
https://github.com/microsoft/pyright/issues/778

modified:   src/flask_uploads/flask_uploads.py
modified:   tests/test_flask_reuploaded.py