### PR TITLE
handle surprising autoserve feature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 unreleased
 ----------
 
-- No changes yet.
+- improve documentation of example app
+- document surprising `autoserve` feature
+- issue a warning when using `autoserve` without explicit configuration
+
 
 0.4.0
 -----

--- a/README.rst
+++ b/README.rst
@@ -54,19 +54,20 @@ Incompatibilities between Flask-Reuploaded and Flask-Uploads
 
 Currently, there are no known incompatibilities.
 
-Just follow the `Uninstall and install` instructions below.
+Just follow the **Uninstall and install** instructions below.
 
 Please note, that `Flask-Uploads`,
 and thus also `Flask-Reuploaded` has an builtin **autoserve** feature.
 
 This means that uploaded files are automatically served for viewing and downloading.
 
-e.g. if you configure an `Uploadset` with the name `photos`,
+e.g. if you configure an `UploadSet` with the name `photos`,
 and upload a picture called `snow.jpg`,
-the picture can be automatically accessed at e.g. `http://localhost:5000/_uploads/photos/snow.jpg`
+the picture can be automatically accessed at e.g.
+http://localhost:5000/_uploads/photos/snow.jpg
 unless
 
-- you set `UPLOADED_PHOTOS_URL` to an empty string, ie `""`
+- you set `UPLOADED_PHOTOS_URL` to an empty string
 - you configure `UPLOADED_PHOTOS_URL` with a valid string (then the picture is served from there)
 - or you set `UPLOADS_AUTOSERVE` to `False`.
 

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Currently, there are no known incompatibilities.
 Just follow the `Uninstall and install` instructions below.
 
 Please note, that `Flask-Uploads`,
-and thus also `Flask-Reuploaded` has an inbuilt **autoserve** feature.
+and thus also `Flask-Reuploaded` has an builtin **autoserve** feature.
 
 This means that uploaded files are automatically served for viewing and downloading.
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,44 @@ Goals
 Migration guide from `Flask-Uploads`
 ------------------------------------
 
+Incompatibilities between Flask-Reuploaded and Flask-Uploads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, there are no known incompatibilities.
+
+Just follow the `Uninstall and install` instructions below.
+
+Please note, that `Flask-Uploads`,
+and thus also `Flask-Reuploaded` has an inbuilt **autoserve** feature.
+
+This means that uploaded files are automatically served for viewing and downloading.
+
+e.g. if you configure an `Uploadset` with the name `photos`,
+and upload a picture called `snow.jpg`,
+the picture can be automatically accessed at e.g. `http://localhost:5000/_uploads/photos/snow.jpg`
+unless
+- you set `UPLOADED_PHOTOS_URL` to an empty string, ie `""`
+- you configure `UPLOADED_PHOTOS_URL` with a valid string
+(then the picture is served from there)
+- or you set `UPLOADS_AUTOSERVE` to `False`.
+
+The last option is new in `Flask-Reuploaded`.
+
+In order to stay compatible with `Flask-Uploads`,
+by default `UPLOADS_AUTOSERVE` is currently set to `True`,
+
+With `Flask-Reuploaded` version 1.0.0,
+`UPLOADS_AUTOSERVE` will default to `False`,
+as this feature is/was undocumented,
+surprising,
+and actually it could lead to unwanted data disclosure.
+
+Setting it explicitly to `False` is recommended.
+
+
+Uninstall and install
+~~~~~~~~~~~~~~~~~~~~~
+
 If you have used `Flask-Uploads` and want to migrate to `Flask-Reuploaded`,
 you only have to install `Flask-Reuploaded` instead of `Flask-Uploads`.
 

--- a/README.rst
+++ b/README.rst
@@ -65,9 +65,9 @@ e.g. if you configure an `Uploadset` with the name `photos`,
 and upload a picture called `snow.jpg`,
 the picture can be automatically accessed at e.g. `http://localhost:5000/_uploads/photos/snow.jpg`
 unless
+
 - you set `UPLOADED_PHOTOS_URL` to an empty string, ie `""`
-- you configure `UPLOADED_PHOTOS_URL` with a valid string
-(then the picture is served from there)
+- you configure `UPLOADED_PHOTOS_URL` with a valid string (then the picture is served from there)
 - or you set `UPLOADS_AUTOSERVE` to `False`.
 
 The last option is new in `Flask-Reuploaded`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,17 @@ serve the uploads.
 By default Flask doesn't put any limits on the size of the uploaded
 data. To limit the max upload size, you can use Flask's `MAX_CONTENT_LENGTH`.
 
+`UPLOADS_AUTOSERVE`
+    This turns `AUTOSERVE` on or off via `True` or `False`.
+    `AUTOSERVE` enables automatic viewing/downloading of uploaded files.
+    When the name of the `UploadSet` is `photos` and the name of the uploaded
+    file is `snow.jpg`, the file is available via
+    `http://localhost:5000/_uploads/photos/snow.jpg`.
+    In order to stay compatible with `Flask-Uploads`,
+    for `Flask-Reuploaded` < 1.0.0 `UPLOADS_AUTOSERVE` defaults to `True`.
+    In version `1.0.0` `UPLOADS_AUTOSERVE` will default to `False`,
+    as this `feature` is a bit of a surprise, as it was undocumented for a long time.
+
 
 Upload Sets
 ===========

--- a/src/flask_uploads/flask_uploads.py
+++ b/src/flask_uploads/flask_uploads.py
@@ -366,6 +366,14 @@ uploads_mod = Blueprint('_uploads', __name__, url_prefix='/_uploads')
 
 @uploads_mod.route('/<setname>/<path:filename>')
 def uploaded_file(setname: UploadSet, filename: str) -> Any:
+    if not current_app.config.get("UPLOADS_AUTOSERVE"):
+        import warnings
+        warnings.warn(
+            "\nYou are using the undocumented AUTOSERVE feature.\n"
+            "With `Flask-Reuploaded` 1.0.0 you have to enable it explicitly.\n"
+            "To do so, you have to configure your app as following:\n"
+            "`app.config['UPLOADS_AUTOSERVE'] = 'True'`"
+        )
     config = current_app.upload_set_config.get(setname)
     if config is None:
         abort(404)

--- a/src/flask_uploads/flask_uploads.py
+++ b/src/flask_uploads/flask_uploads.py
@@ -120,9 +120,11 @@ def configure_uploads(app: Flask, upload_sets: Iterable['UploadSet']) -> None:
         config = config_for_set(uset, app, defaults)
         set_config[uset.name] = config
 
-    should_serve = any(s.base_url is None for s in set_config.values())
-    if '_uploads' not in app.blueprints and should_serve:
-        app.register_blueprint(uploads_mod)
+    autoserve = app.config.get("UPLOADS_AUTOSERVE", True)
+    if autoserve:
+        should_serve = any(s.base_url is None for s in set_config.values())
+        if '_uploads' not in app.blueprints and should_serve:
+            app.register_blueprint(uploads_mod)
 
 
 class UploadConfiguration:

--- a/tests/test_autoserve.py
+++ b/tests/test_autoserve.py
@@ -1,0 +1,138 @@
+import os
+
+from flask import Flask
+from flask_uploads import ALL
+from flask_uploads import IMAGES
+from flask_uploads import UploadSet
+from flask_uploads import configure_uploads
+
+SIMPLE_PICTURE = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x05\x00\x00\x00\x05"
+    b"\x08\x02\x00\x00\x00\x02\r\xb1\xb2\x00\x00\x00\x0cIDAT\x08\xd7c`\xa0."
+    b'\x00\x00\x00P\x00\x01"\x13\xe8u\x00\x00\x00\x00IEND\xaeB`\x82'
+)
+
+
+def test_autoserve_works_without_configuration(tmp_path):
+    """this *feature* was pretty much undocumented
+
+    It could lead to unwanted data disclosure.
+    """
+    static = tmp_path / "static"
+    static.mkdir()
+    image_directory = static / "images"
+    image_directory.mkdir()
+    p = image_directory / "snow.jpg"
+    p.write_bytes(SIMPLE_PICTURE)
+
+    app = Flask(__name__)
+    photos = UploadSet("photos", IMAGES)
+    app.config["UPLOADED_PHOTOS_DEST"] = str(image_directory)
+    app.config["SECRET_KEY"] = os.urandom(24)
+    configure_uploads(app, photos)
+
+    with app.test_client() as client:
+        response = client.get("/_uploads/photos/snow.jpg")
+
+    assert response.status == "200 OK"
+
+
+def test_autoserve_does_not_work_for_non_existing_upload_set(tmp_path):
+    """
+    ie here a `files` UploadSet is defined,
+    but the client tries to access `photos`
+
+    Although the file is present,
+    it cannot be accessed via the `photos` route.
+    """
+
+    static = tmp_path / "static"
+    static.mkdir()
+    image_directory = static / "images"
+    image_directory.mkdir()
+    p = image_directory / "snow.jpg"
+    p.write_bytes(SIMPLE_PICTURE)
+
+    app = Flask(__name__)
+    files = UploadSet("files", ALL)
+    app.config["UPLOADED_FILES_DEST"] = str(image_directory)
+    app.config["SECRET_KEY"] = os.urandom(24)
+    configure_uploads(app, files)
+
+    with app.test_client() as client:
+        response = client.get("/_uploads/photos/snow.jpg")
+
+    assert response.status == "404 NOT FOUND"
+
+
+def test_autoserve_gets_deactivated_when_configuring_url_with_empty_string(
+        tmp_path):
+    static = tmp_path / "static"
+    static.mkdir()
+    image_directory = static / "images"
+    image_directory.mkdir()
+    p = image_directory / "snow.jpg"
+    p.write_bytes(SIMPLE_PICTURE)
+
+    app = Flask(__name__)
+    photos = UploadSet("photos", IMAGES)
+    app.config["UPLOADED_PHOTOS_DEST"] = str(image_directory)
+    app.config["SECRET_KEY"] = os.urandom(24)
+
+    # this deactivates autoserve
+    app.config["UPLOADED_PHOTOS_URL"] = ""
+
+    configure_uploads(app, photos)
+
+    with app.test_client() as client:
+        response = client.get("/_uploads/photos/snow.jpg")
+
+    assert response.status == "404 NOT FOUND"
+
+
+def test_autoserve_gets_deactivated_when_configuring_uploaded_url(tmp_path):
+    static = tmp_path / "static"
+    static.mkdir()
+    image_directory = static / "images"
+    image_directory.mkdir()
+    p = image_directory / "snow.jpg"
+    p.write_bytes(SIMPLE_PICTURE)
+
+    app = Flask(__name__)
+    photos = UploadSet("photos", IMAGES)
+    app.config["UPLOADED_PHOTOS_DEST"] = str(image_directory)
+    app.config["SECRET_KEY"] = os.urandom(24)
+
+    # configuring this deactivates autoserve
+    app.config["UPLOADED_PHOTOS_URL"] = "https://example.com/images"
+
+    configure_uploads(app, photos)
+
+    with app.test_client() as client:
+        response = client.get("/_uploads/photos/snow.jpg")
+
+    assert response.status == "404 NOT FOUND"
+
+
+def test_autoserve_gets_deactivated_when_set_autoserve_to_false(tmp_path):
+    static = tmp_path / "static"
+    static.mkdir()
+    image_directory = static / "images"
+    image_directory.mkdir()
+    p = image_directory / "snow.jpg"
+    p.write_bytes(SIMPLE_PICTURE)
+
+    app = Flask(__name__)
+    photos = UploadSet("photos", IMAGES)
+    app.config["UPLOADED_PHOTOS_DEST"] = str(image_directory)
+    app.config["SECRET_KEY"] = os.urandom(24)
+
+    # configuring this deactivates autoserve
+    app.config["UPLOADS_AUTOSERVE"] = False
+
+    configure_uploads(app, photos)
+
+    with app.test_client() as client:
+        response = client.get("/_uploads/photos/snow.jpg")
+
+    assert response.status == "404 NOT FOUND"


### PR DESCRIPTION
`Flask-Uploads` and thus also `Flask-Reuploaded` automatically create a
blueprint for serving uploaded files.

This was not properly documented and is pretty surprising, as it could
lead to unwanted data disclosure.

As a first step, this behavior now is both documented, and can also be
deactivated by setting `UPLOADS_AUTOSERVE` to `False`.

In `Flask-Reuploaded` 1.0.0 `UPLOADS_AUTOSERVE` will default to `False`.

**todos**
- [x]  add tests
- [x]  add warning about upcoming new default for autoserve

This will fix #24 - once finished.