### PR TITLE
deactivate `autoserve` by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ unreleased
 - raise test coverage to 100%
 - use official `Pallets` theme for the documentation
 - remove deprecated `patch_request_class` helper function; use `MAX_CONTENT_LENGTH` instead.
+- `autoserve` now has been deactivated by default and needs explicit activation
+   via setting `UPLOADS_AUTOSERVE=True`
 
 
 0.5.0

--- a/README.rst
+++ b/README.rst
@@ -59,35 +59,11 @@ Nevertheless, there are the following known incompatibilities:
 
 - the `patch_request_class` helper function has been removed;
   the function was only necessary for Flask 0.6 and earlier.
-
-Please note, that `Flask-Uploads`,
-and thus also `Flask-Reuploaded` has an builtin **autoserve** feature.
-
-This means that uploaded files are automatically served for viewing and downloading.
-
-e.g. if you configure an `UploadSet` with the name `photos`,
-and upload a picture called `snow.jpg`,
-the picture can be automatically accessed at e.g.
-http://localhost:5000/_uploads/photos/snow.jpg
-unless
-
-- you set `UPLOADED_PHOTOS_URL` to an empty string
-- you configure `UPLOADED_PHOTOS_URL` with a valid string (then the picture is served from there)
-- or you set `UPLOADS_AUTOSERVE` to `False`.
-
-The last option is new in `Flask-Reuploaded`.
-
-In order to stay compatible with `Flask-Uploads`,
-by default `UPLOADS_AUTOSERVE` is currently set to `True`,
-
-With `Flask-Reuploaded` version 1.0.0,
-`UPLOADS_AUTOSERVE` will default to `False`,
-as this feature is/was undocumented,
-surprising,
-and actually it could lead to unwanted data disclosure.
-
-Setting it explicitly to `False` is recommended.
-
+- `autoserve` of uploaded images now has been deactivated;
+  this was a poorly documented "feature",
+  which even could have lead to unwanted data disclosure;
+  if you want to activate the feature again,
+  you need to set `UPLOADS_AUTOSERVE=True`
 
 Uninstall and install
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,8 +105,8 @@ data. To limit the max upload size, you can use Flask's `MAX_CONTENT_LENGTH`.
     file is `snow.jpg`, the file is available via
     `http://localhost:5000/_uploads/photos/snow.jpg`.
     In order to stay compatible with `Flask-Uploads`,
-    for `Flask-Reuploaded` < 1.0.0 `UPLOADS_AUTOSERVE` defaults to `True`.
-    In version `1.0.0` `UPLOADS_AUTOSERVE` will default to `False`,
+    for `Flask-Reuploaded` < 1.0.0 `UPLOADS_AUTOSERVE` defaulted to `True`.
+    Since version `1.0.0` `UPLOADS_AUTOSERVE` defaults to `False`,
     as this `feature` is a bit of a surprise, as it was undocumented for a long time.
 
 
@@ -240,6 +240,7 @@ Backwards Compatibility
 Version 1.0 (unreleased)
 ------------------------
 * Removal of `patch_request_class`
+* `autoserve` is now deactivated by default
 
 
 Version 0.1.3

--- a/src/flask_uploads/flask_uploads.py
+++ b/src/flask_uploads/flask_uploads.py
@@ -368,14 +368,6 @@ uploads_mod = Blueprint('_uploads', __name__, url_prefix='/_uploads')
 
 @uploads_mod.route('/<setname>/<path:filename>')
 def uploaded_file(setname: UploadSet, filename: str) -> Any:
-    if not current_app.config.get("UPLOADS_AUTOSERVE"):
-        import warnings
-        warnings.warn(
-            "\nYou are using the undocumented AUTOSERVE feature.\n"
-            "With `Flask-Reuploaded` 1.0.0 you have to enable it explicitly.\n"
-            "To do so, you have to configure your app as following:\n"
-            "`app.config['UPLOADS_AUTOSERVE'] = 'True'`"
-        )
     config = current_app.upload_set_config.get(setname)
     if config is None:
         abort(404)

--- a/src/flask_uploads/flask_uploads.py
+++ b/src/flask_uploads/flask_uploads.py
@@ -120,7 +120,7 @@ def configure_uploads(app: Flask, upload_sets: Iterable['UploadSet']) -> None:
         config = config_for_set(uset, app, defaults)
         set_config[uset.name] = config
 
-    autoserve = app.config.get("UPLOADS_AUTOSERVE", True)
+    autoserve = app.config.get("UPLOADS_AUTOSERVE", False)
     if autoserve:
         should_serve = any(s.base_url is None for s in set_config.values())
         if '_uploads' not in app.blueprints and should_serve:

--- a/tests/test_flask_reuploaded.py
+++ b/tests/test_flask_reuploaded.py
@@ -369,6 +369,7 @@ class TestPathsAndURLs:
         app.config.update(
             UPLOADED_FILES_DEST='/uploads'
         )
+        app.config["UPLOADS_AUTOSERVE"] = True
         uset = UploadSet('files')
         configure_uploads(app, uset)
         with app.test_request_context():


### PR DESCRIPTION
The automatic serving of uploaded images/files was very surpsing, as it
was badly documented.

It could even lead to data leak, as it was also activated by default.

Now, it is an opt-in, so if you want the behavior of `Flask-Uploads`,
you need to set `UPLOADS_AUTOSERVE=True`

This is the first major backwards incompatibility with `Flask-Uploads`.