### PR TITLE
make type checkers aware of the type annotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 unreleased
 ----------
-- nothing yet
+- make type checkers aware that this library is using type annotations
 
 
 1.0.0 (2021.04.07)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ include *.yaml
 include *.toml
 include tox.ini
 recursive-include tests *.py
+# make type checkers aware of type annotations
+include src/flask_uploads/py.typed
 
 recursive-include docs *.txt
 include docs/Makefile

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     package_dir={"": "src"},
     zip_safe=False,
     platforms="any",
+    include_package_data=True,
     install_requires=["Flask>=1.0.4"],
     extras_require={
         "test": [


### PR DESCRIPTION
It is not enough to have type annotations, you must include an emtpy
file with the name `py.typed`.