### PR TITLE
add contexts to the coverage report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ unreleased
 1.1.0 (2021.05.09)
 ------------------
 - make type checkers aware that this library is using type annotations
+- add contexts to coverage report
 
 
 1.0.0 (2021.04.07)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands = pytest {posargs}
 
 [testenv:coverage]
 commands =
-    pytest --cov tests --cov flask_uploads --cov-report term-missing --cov-report html --cov-fail-under=100 {posargs}
+    pytest --cov tests --cov flask_uploads --cov-report term-missing --cov-report html --cov-context=test --cov-fail-under=100 {posargs}
 
 [testenv:pre-commit]
 deps = pre-commit
@@ -41,6 +41,9 @@ ignore =
 source =
     src/
     .tox/*/lib/python*/site-packages/
+
+[coverage:html]
+show_contexts = true
 
 [pytest]
 # only collect intended test classes, e.g. TestSaving


### PR DESCRIPTION
ie show which tests hit which lines of code