### PR TITLE
Update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,39 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 8.0.0
     hooks:
     - id: isort
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: debug-statements
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
     - id: flake8
-      additional_dependencies: [flake8-bugbear==22.12.6]
+      additional_dependencies: [flake8-bugbear==25.11.29]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.21.2
     hooks:
     - id: pyupgrade
       args: [--py310-plus]
 
   - repo: https://github.com/mgedmin/check-python-versions
-    rev: 0.22.1
+    rev: 0.24.0
     hooks:
     - id: check-python-versions
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: '0.50'
+    rev: '0.51'
     hooks:
     - id: check-manifest
       args: [--no-build-isolation]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.0
+    rev: 1.9.3
     hooks:
     - id: bandit
       args:


### PR DESCRIPTION
- Update isort from 5.13.2 to 8.0.0
- Update pre-commit-hooks from v5.0.0 to v6.0.0
- Update flake8 from 7.1.1 to 7.3.0
- Update flake8-bugbear from 22.12.6 to 25.11.29
- Update pyupgrade from v3.19.0 to v3.21.2
- Update check-python-versions from 0.22.1 to 0.24.0
- Update check-manifest from 0.50 to 0.51
- Update bandit from 1.8.0 to 1.9.3
