### PR TITLE
Fix extension issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.6.0 (unreleased)
+1.6.0 (2026.06.06)
 ------------------
 - **SECURITY FIX**: Ensure overridden file names are normalized via
   ``lowercase_ext()`` prior to extension validation checking and writing to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.6.0 (unreleased)
+------------------
+- **SECURITY FIX**: Ensure overridden file names are normalized via
+  ``lowercase_ext()`` prior to extension validation checking and writing to
+  disk.
+
 1.5.0 (2026.02.21)
 ------------------
 - drop support for Python 3.8 and 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "Flask-Reuploaded"
 version = "1.6.0"
 description = "Flexible and efficient upload handling for Flask"
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "Matthew \"LeafStorm\" Frazier", email = "leafstormrush@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Flask-Reuploaded"
-version = "1.5.0"
+version = "1.6.0"
 description = "Flexible and efficient upload handling for Flask"
 license = {text = "MIT"}
 authors = [

--- a/src/flask_uploads/flask_uploads.py
+++ b/src/flask_uploads/flask_uploads.py
@@ -340,6 +340,8 @@ class UploadSet:
             else:
                 basename = name
 
+            basename = lowercase_ext(basename)
+
             # Re-validate extension after name override
             ext = extension(basename)
             if ext and not self.extension_allowed(ext):

--- a/tests/test_flask_reuploaded.py
+++ b/tests/test_flask_reuploaded.py
@@ -3,11 +3,12 @@
 :copyright: 2019-2020 Jürgen Gmach <juergen.gmach@googlemail.com>
 :license:   MIT/X11, see LICENSE for details
 """
-
 import os
 import os.path
 import shutil
 import tempfile
+from collections.abc import Iterable
+from typing import cast
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -16,6 +17,7 @@ from flask import Flask
 from flask import url_for
 from flask_uploads import ALL
 from flask_uploads import IMAGES
+from flask_uploads import SCRIPTS
 from flask_uploads import AllExcept
 from flask_uploads import TestingFileStorage
 from flask_uploads import UploadConfiguration
@@ -447,6 +449,20 @@ class TestSecurityFixes:
                 uset.save(tfs, name="backdoor.py")
 
             assert "py" in str(exc_info.value).lower()
+
+    def test_extension_bypass_case_folding_via_name_parameter(self) -> None:
+        """Verify extension validation cannot be bypassed via `name` using...
+
+        uppercase/mixed-case extension."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uset = UploadSet("files", cast(Iterable[str], AllExcept(SCRIPTS)))
+            uset._config = Config(tmpdir)
+            tfs = TestingFileStorage(filename="safe.txt")
+
+            with pytest.raises(UploadNotAllowed) as exc_info:
+                uset.save(tfs, name="backdoor.PHP")
+
+            assert "php" in str(exc_info.value).lower()
 
     def test_extension_bypass_with_double_extension(self) -> None:
         """Verify double extensions don't bypass validation."""


### PR DESCRIPTION
Fix extension-denylist bypass via case-folding asymmetry in name override

An incomplete-fix variant of CVE-2026-27641 (tracked under GHSA-937x-gpqr-72gg)
allowed a denylist bypass when a custom `name` was provided to `UploadSet.save()`.

In the default path, filenames are sanitized and normalized using `lowercase_ext()`
prior to validation. In the name override path, the extension on the custom
name was case-preserved (e.g. "backdoor.PHP") and validated via `extension()`, which
did not check lowercasing against lowercase denylist policies (such as `AllExcept`).

This is fixed by normalizing the target filename via `lowercase_ext()` prior to
re-validation and storage, matching the default upload flow.
