### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   tests:


### PR DESCRIPTION
Potential fix for [https://github.com/jugmac00/flask-reuploaded/security/code-scanning/1](https://github.com/jugmac00/flask-reuploaded/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (recommended here, since there is one job) to enforce least privilege for all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current behavior for checkout and test execution while preventing unnecessary default write scopes.  
Edit **`.github/workflows/main.yml`** by inserting the `permissions` block between `workflow_dispatch:` and `jobs:`.

No imports, methods, or extra definitions are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
